### PR TITLE
Fixed bug in MongoDB cookbook

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -29,6 +29,15 @@ user "mongodb" do
   shell "/bin/false"
 end
 
+[node[:mongodb][:dir], "#{node[:mongodb][:dir]}/bin", node[:mongodb][:datadir]].each do |dir|
+  directory dir do
+    owner "mongodb"
+    group "mongodb"
+    mode 0755
+    recursive true
+  end
+end
+
 unless `ps -A -o command | grep "[m]ongo"`.include? node[:mongodb][:version]
   remote_file "/tmp/mongodb-#{node[:mongodb][:version]}.tar.gz" do
     source node[:mongodb][:source]
@@ -41,15 +50,6 @@ unless `ps -A -o command | grep "[m]ongo"`.include? node[:mongodb][:version]
     code <<-EOH
       tar -zxf mongodb-#{node[:mongodb][:version]}.tar.gz --strip-components=2 -C #{node[:mongodb][:dir]}/bin
     EOH
-  end
-end
-
-[node[:mongodb][:dir], "#{node[:mongodb][:dir]}/bin", node[:mongodb][:datadir]].each do |dir|
-  directory dir do
-    owner "mongodb"
-    group "mongodb"
-    mode 0755
-    recursive true
   end
 end
 


### PR DESCRIPTION
Hi,

Fixed issue in 'Setting up MongoDB' where node[:mongodb][:dir]}/bin couldn't be found

Regards,
Ijonas.
