### PR TITLE
Fix empty replSet

### DIFF
--- a/templates/default/mongodb.conf.erb
+++ b/templates/default/mongodb.conf.erb
@@ -135,6 +135,6 @@ nssize = <%= @node[:mongodb][:nssize] %>
   opIdMem = <%= @node[:mongodb][:opidmem] * 1024 * 1024 %>
 <% end %>
 
-<% if @node[:mongodb][:replica_set] %>
+<% unless @node[:mongodb][:replica_set].empty? %>
   replSet = <%= @node[:mongodb][:replica_set] %>
 <% end %>


### PR DESCRIPTION
An empty replSet value causes MongoDB to fail to start in Ubuntu 10.04 with MongoDB 1.6.5. This branch fixes that.
