### PR TITLE
Feature parity between source and apt installation methods

### DIFF
--- a/attributes/mongodb.rb
+++ b/attributes/mongodb.rb
@@ -11,6 +11,7 @@ default[:mongodb][:config]      = "/etc/mongodb.conf"
 default[:mongodb][:logfile]     = "/var/log/mongodb.log"
 default[:mongodb][:pidfile]     = "/var/run/mongodb.pid"
 default[:mongodb][:port]        = 27017
+default[:mongodb][:init_system] = "sysv"
 
 default[:mongodb][:bind_ip] = \
   if node[:network][:interfaces][:eth0]

--- a/metadata.rb
+++ b/metadata.rb
@@ -159,13 +159,13 @@ attribute "mongodb/nssize",
 attribute "mongodb/rest",
   :display_name => "MongoDB REST",
   :description => "Enables REST interface for extra info on Http Interface",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::server", "mongodb::config_server"],
   :default => "false"
 
 attribute "mongodb/syncdelay",
   :display_name => "MongoDB syncdelay",
   :description => "Controls how often changes are flushed to disk",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::server", "mongodb::config_server"],
   :default => "60"
 
 
@@ -234,14 +234,14 @@ attribute "mongodb/opidmem",
 attribute "mongodb/replica_set",
   :display_name => "MongoDB replica set", 
   :description => "Name of a replica set for server to join, passed directly to mongod with --replSet option",
-  :recipes => ["mongodb::source"]
+  :recipes => ["mongodb::server"]
 
 
 # Sharding
 attribute "mongodb/shard_server",
   :display_name => "MongoDB shard server",
   :description => "Specify that server should participate in sharding, by passing --shardsvr to mongod startup",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::server"],
   :default => false
 
 
@@ -302,36 +302,36 @@ attribute "mongodb/backup/maxemailsize",
 attribute "mongodb/config_server/datadir",
   :display_name => "MongoDB config server data store",
   :description => "All MongoDB config server data will be stored here",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::config_server"],
   :default => "/var/db/mongodb-config"
 
 attribute "mongodb/config_server/config",
   :display_name => "MongoDB config server configuration",
   :description => "Path to MongoDB config server config file",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::config_server"],
   :default => "/etc/mongodb-config.conf"
 
 attribute "mongodb/config_server/logfile",
   :display_name => "MongoDB config server log file",
   :description => "MongoDB config server will log to this file",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::config_server"],
   :default => "/var/log/mongodb-config.log"
 
 attribute "mongodb/config_server/pidfile",
   :display_name => "MongoDB config server PID file",
   :description => "Path to MongoDB config server PID file",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::config_server"],
   :default => "/var/run/mongodb-config.pid"
 
 # FIXME: doesn't appear to be used
 attribute "mongodb/config_server/host",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::config_server"],
   :default => "localhost"
 
 attribute "mongodb/config_server/port",
   :display_name => "MongoDB config server port",
   :description => "Accept config server connections on the specified port",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::config_server"],
   :default => 27019
 
 
@@ -339,29 +339,29 @@ attribute "mongodb/config_server/port",
 attribute "mongodb/mongos/config",
   :display_name => "MongoDB sharding router configuration",
   :description => "Path to MongoDB sharding router (mongos) config file",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::mongos"],
   :default => "/etc/mongos.conf"
 
 attribute "mongodb/mongos/logfile",
   :display_name => "MongoDB sharding router log file",
   :description => "MongoDB sharding router (mongos) will log to this file",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::mongos"],
   :default => "/var/log/mongos.log"
 
 attribute "mongodb/mongos/pidfile",
   :display_name => "MongoDB sharding router PID file",
   :description => "Path to MongoDB sharding router (mongos) PID file",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::mongos"],
   :default => "/var/run/mongos.pid"
 
 # FIXME: doesn't appear to be used
 attribute "mongodb/mongos/host",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::mongos"],
   :default => "localhost"
 
 attribute "mongodb/mongos/port",
   :display_name => "MongoDB sharding router port",
   :description => "Accept sharding router (mongos) connections on the specified port. Clients will normally connect to this just as they would a database server.",
-  :recipes => ["mongodb::source"],
+  :recipes => ["mongodb::mongos"],
   :default => 27017
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -74,6 +74,12 @@ attribute "mongodb/port",
   :description => "Accept connections on the specified port",
   :default => "27017"
 
+attribute "mongodb/init_system",
+  :display_name => "MongoDB init System",
+  :description => "Init system to use for mongo servers",
+  :choice => ["sysv", "upstart"],
+  :default => "sysv"
+
 attribute "mongodb/bind_ip",
   :display_name => "MongoDB bind IP",
   :description => "Accept connections on the interface with the given IP, or 0.0.0.0 for all",

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -37,5 +37,3 @@ template "/etc/apt/sources.list.d/mongodb.list" do
 end
 
 package "mongodb-stable"
-
-node[:mongodb][:installed_from] = "apt"

--- a/recipes/config_server.rb
+++ b/recipes/config_server.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-installation_source = node[:mongodb][:installed_from]
+init_system = node[:mongodb][:init_system]
 server_init = Mash.new(
   :type     => "config_server",
   :daemon   => "mongod",
@@ -50,8 +50,8 @@ template node[:mongodb][:config_server][:config] do
   variables({:is_config_server => true})
 end
 
-case installation_source
-when "apt"
+case init_system
+when "upstart"
   template "/etc/init/mongodb-config.conf" do
     source "mongod.upstart.erb"
     owner "root"
@@ -60,7 +60,7 @@ when "apt"
     backup false
     variables(:server_init => server_init)
   end
-when "src"
+when "sysv"
   template "/etc/init.d/mongodb-config" do
     source "mongodb.init.erb"
     mode 0755
@@ -73,8 +73,8 @@ service "mongodb-config" do
   supports :start => true, :stop => true, "force-stop" => true, :restart => true, "force-reload" => true, :status => true
   action [:enable, :start]
   subscribes :restart, resources(:template => node[:mongodb][:config_server][:config])
-  case installation_source
-  when "apt"
+  case init_system
+  when "upstart"
     subscribes :restart, resources(:template => "/etc/init/mongodb-config.conf")
     provider Chef::Provider::Service::Upstart
   else

--- a/recipes/config_server.rb
+++ b/recipes/config_server.rb
@@ -82,10 +82,12 @@ service "mongodb-config" do
   end
 end
 
-# cookbook_file "/etc/logrotate.d/mongodb-config" do
-#   source "logrotate"
-#   cookbook "mongodb"
-#   owner "mongodb"
-#   group "mongodb"
-#   mode "0644"
-# end
+template "/etc/logrotate.d/#{server_init[:basename]}" do
+  source "mongodb.logrotate.erb"
+  owner "mongodb"
+  group "mongodb"
+  mode "0644"
+  backup false
+  variables(:logfile => node[:mongodb][:config_server][:logfile])
+end
+

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -78,10 +78,12 @@ service "mongos" do
   end
 end
 
-# cookbook_file "/etc/logrotate.d/mongos" do
-#   source "logrotate"
-#   cookbook "mongodb"
-#   owner "mongodb"
-#   group "mongodb"
-#   mode "0644"
-# end
+template "/etc/logrotate.d/#{server_init[:basename]}" do
+  source "mongodb.logrotate.erb"
+  owner "mongodb"
+  group "mongodb"
+  mode "0644"
+  backup false
+  variables(:logfile => node[:mongodb][:mongos][:logfile])
+end
+

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-installation_source = node[:mongodb][:installed_from]
+init_system = node[:mongodb][:init_system]
 server_init = Mash.new(
   :type     => "mongodb",
   :daemon   => "mongod",
@@ -49,8 +49,8 @@ template node[:mongodb][:config] do
   backup false
 end
 
-case installation_source
-when "apt"
+case init_system
+when "upstart"
   template '/etc/init/mongodb.conf' do
     source "mongod.upstart.erb"
     owner "root"
@@ -59,7 +59,7 @@ when "apt"
     backup false
     variables(:server_init => server_init)
   end
-when "src"
+when "sysv"
   template "/etc/init.d/mongodb" do
     source "mongodb.init.erb"
     mode 0755
@@ -72,8 +72,8 @@ service "mongodb" do
   supports :start => true, :stop => true, "force-stop" => true, :restart => true, "force-reload" => true, :status => true
   action [:enable, :start]
   subscribes :restart, resources(:template => node[:mongodb][:config])
-  case installation_source
-  when "apt"
+  case init_system
+  when "upstart"
     subscribes :restart, resources(:template => "/etc/init/mongodb.conf")
     provider Chef::Provider::Service::Upstart
   else

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -81,10 +81,12 @@ service "mongodb" do
   end
 end
 
-cookbook_file "/etc/logrotate.d/mongodb" do
-  source "logrotate"
-  cookbook "mongodb"
+template "/etc/logrotate.d/#{server_init[:basename]}" do
+  source "mongodb.logrotate.erb"
   owner "mongodb"
   group "mongodb"
   mode "0644"
+  backup false
+  variables(:logfile => node[:mongodb][:logfile])
 end
+

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -58,5 +58,3 @@ environment = File.read('/etc/environment')
 unless environment.include? node[:mongodb][:dir]
   File.open('/etc/environment', 'w') { |f| f.puts environment.gsub(/PATH="/, "PATH=\"#{node[:mongodb][:dir]}/bin:") }
 end
-
-node[:mongodb][:installed_from] = "src"

--- a/templates/default/mongod.upstart.erb
+++ b/templates/default/mongod.upstart.erb
@@ -1,9 +1,15 @@
-# Ubuntu upstart file at /etc/init/mongodb.conf
+<% server_type = @server_init[:type] %>
+# Ubuntu upstart file at /etc/init/<%= @server_init[:basename] %>.conf
 # Managed by Chef, no touchy.
 
 pre-start script
+    <% if server_type == 'mongodb' %>
     mkdir -p <%= node[:mongodb][:datadir] %>
     mkdir -p <%= File.dirname(node[:mongodb][:logfile]) %>
+    <% else %>
+    mkdir -p <%= node[:mongodb][server_type][:datadir] %>
+    mkdir -p <%= File.dirname(node[:mongodb][server_type][:logfile]) %>
+    <% end %>
 end script
 
 start on runlevel [2345]
@@ -11,6 +17,61 @@ stop on runlevel [06]
 
 script
   ENABLE_MONGODB="yes"
-  if [ -f /etc/default/mongodb ]; then . /etc/default/mongodb; fi
-  if [ "x$ENABLE_MONGODB" = "xyes" ]; then exec start-stop-daemon --start --quiet --chuid mongodb --exec  /usr/bin/mongod -- --config <%= node[:mongodb][:config] %>; fi
+
+  DAEMON=<%= @server_init[:daemon] %>
+  NAME=<%= @server_init[:basename] %>
+
+  # Default defaults.  Can be overridden by the /etc/default/$NAME
+  <% if server_type == 'mongodb' %>
+  CONF=<%= @node[:mongodb][:config] %>
+  PIDFILE=<%= @node[:mongodb][:pidfile] %>
+  <% else %>
+  CONF=<%= @node[:mongodb][server_type][:config] %>
+  PIDFILE=<%= @node[:mongodb][server_type][:pidfile] %>
+  <% end %>
+
+  <% case server_type; when 'config_server' %>
+  CONFIGSVR=--configsvr
+  <% when 'mongos' %>
+  CONFIGDB="--configdb <%= @configdb_server_list %>"
+  <% else %>
+  REPLSET=<%= @node[:mongodb][:replica_set] %>
+  SHARDSVR=<%= @node[:mongodb][:shard_server] %>
+  <% end %>
+
+  <% unless server_type == 'mongos' %>
+  REST=<%= @node[:mongodb][:rest] %>
+  SYNCDELAY="--syncdelay <%= @node[:mongodb][:syncdelay] %>"
+  <% end %>
+
+  if [ -f /etc/default/$NAME ]; then . /etc/default/$NAME; fi
+
+  # Check for daemon bin
+  if test ! -x $DAEMON; then
+    echo "Could not find $DAEMON"
+    exit 0
+  fi
+
+  # This will enable the REST Interface for MongoDB if told so
+  if test "x$REST" = "xtrue"; then
+    REST=--rest
+  else
+    REST=
+  fi
+
+  # This will make the server part of a replica set
+  if test "x$REPLSET" = "x"; then
+    REPLSET=
+  else
+    REPLSET="--replSet $REPLSET"
+  fi
+
+  # This will make the server participate in sharding
+  if test "x$SHARDSVR" = "xtrue"; then
+    SHARDSVR=--shardsvr
+  else
+    SHARDSVR=
+  fi
+
+  if [ "x$ENABLE_MONGODB" = "xyes" ]; then exec start-stop-daemon --start --quiet --chuid mongodb --exec  /usr/bin/$DAEMON -- $REST $REPLSET $SHARDSVR $CONFIGSVR $SYNCDELAY $CONFIGDB --config $CONF; fi
 end script

--- a/templates/default/mongodb.conf.erb
+++ b/templates/default/mongodb.conf.erb
@@ -7,26 +7,19 @@
 # Note: if you run mongodb as a non-root user (recommended) you may
 # need to create and set permissions for this directory manually,
 # e.g., if the parent directory isn't mutable by the mongodb user.
+
 <% if @is_config_server %>
 dbpath=<%= @node[:mongodb][:config_server][:datadir] %>
-<% else %>
-dbpath=<%= @node[:mongodb][:datadir] %>
-<% end %>
-
-#where to log
-<% if @is_config_server %>
 logpath=<%= @node[:mongodb][:config_server][:logfile] %>
-<% else %>
-logpath=<%= @node[:mongodb][:logfile] %>
-<% end %>
-logappend=true
-
-bind_ip = <%= @node[:mongodb][:bind_ip] %>
-<% if @is_config_server %>
 port = <%= @node[:mongodb][:config_server][:port] %>
 <% else %>
+dbpath=<%= @node[:mongodb][:datadir] %>
+logpath=<%= @node[:mongodb][:logfile] %>
 port = <%= @node[:mongodb][:port] %>
 <% end %>
+
+logappend=true
+bind_ip = <%= @node[:mongodb][:bind_ip] %>
 
 <% if @node[:mongodb][:log_cpu_io] %>
 # Enables periodic logging of CPU utilization and I/O wait

--- a/templates/default/mongodb.init.erb
+++ b/templates/default/mongodb.init.erb
@@ -48,34 +48,31 @@
 #                    functionality are the goals for the project.
 ### END INIT INFO
 
+<% server_type = @server_init[:type] %>
 PATH=<%= @node[:mongodb][:dir] %>/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-<% if @is_mongos %>
-DAEMON=<%= @node[:mongodb][:dir] %>/bin/mongos
-<% else %>
-DAEMON=<%= @node[:mongodb][:dir] %>/bin/mongod
-<% end %>
+DAEMON=<%= @node[:mongodb][:dir] %>/bin/<%= @server_init[:daemon] %>
 DESC=database
+NAME=<%= @server_init[:basename] %>
 
 # Default defaults.  Can be overridden by the /etc/default/$NAME
-<% if @is_config_server %>
-NAME=mongodb-config
-CONF=<%= @node[:mongodb][:config_server][:config] %>
-PIDFILE=<%= @node[:mongodb][:config_server][:pidfile] %>
-CONFIGSVR=--configsvr
-<% elsif @is_mongos %>
-NAME=mongos
-CONF=<%= @node[:mongodb][:mongos][:config] %>
-PIDFILE=<%= @node[:mongodb][:mongos][:pidfile] %>
-CONFIGDB="--configdb <%= @configdb_server_list %>"
-<% else %>
-NAME=mongodb
+<% if server_type == 'mongodb' %>
 CONF=<%= @node[:mongodb][:config] %>
-REPLSET=<%= @node[:mongodb][:replica_set] %>
-SHARDSVR=<%= @node[:mongodb][:shard_server] %>
 PIDFILE=<%= @node[:mongodb][:pidfile] %>
+<% else %>
+CONF=<%= @node[:mongodb][server_type][:config] %>
+PIDFILE=<%= @node[:mongodb][server_type][:pidfile] %>
 <% end %>
 
-<% unless @is_mongos %>
+<% case server_type; when 'config_server' %>
+CONFIGSVR=--configsvr
+<% when 'mongos' %>
+CONFIGDB="--configdb <%= @configdb_server_list %>"
+<% else %>
+REPLSET=<%= @node[:mongodb][:replica_set] %>
+SHARDSVR=<%= @node[:mongodb][:shard_server] %>
+<% end %>
+
+<% unless server_type == 'mongos' %>
 REST=<%= @node[:mongodb][:rest] %>
 SYNCDELAY="--syncdelay <%= @node[:mongodb][:syncdelay] %>"
 <% end %>

--- a/templates/default/mongodb.logrotate.erb
+++ b/templates/default/mongodb.logrotate.erb
@@ -1,4 +1,4 @@
-/var/log/mongodb.log {
+<%= @logfile %> {
   daily
   missingok
   notifempty
@@ -10,3 +10,4 @@
   compressext .bz2
   dateext
 }
+


### PR DESCRIPTION
As I noted in #9, there were discrepancies between the apt and source installation methods for configuration supported by recently added features. This, I think, brings everything into alignment (can't say I've tested every possible permutation but it ought to be pretty close...).

I've addressed the matter of upstart for Ubuntu init for now by making it a configurable attribute, because that's basically what the recently added `installed_from` node attribute was being used for anyway. It appears that Ubuntu ordinarily has an upstart compatibility layer for `sysv` init out of the box, so it's largely moot, but I guess this is future-friendly while the `sysv` default could work for Red Hat, etc. if support is added to the cookbook in the future.
