### PR TITLE
Upgrade 1.8

### DIFF
--- a/attributes/mongodb.rb
+++ b/attributes/mongodb.rb
@@ -1,8 +1,8 @@
 ### SOURCE PACKAGES
-default[:mongodb][:version]           = "1.6.5"
+default[:mongodb][:version]           = "1.8.0"
 default[:mongodb][:source]            = "http://fastdl.mongodb.org/linux/mongodb-linux-#{node[:kernel][:machine]}-#{mongodb[:version]}.tgz"
-default[:mongodb][:i686][:checksum]   = "c2b8dfed2c003ddfab535f0b6dff64d2"
-default[:mongodb][:x86_64][:checksum] = "0a64adafd9772b6b2d748c3b088bd895"
+default[:mongodb][:i686][:checksum]   = "b0b4d98968960cc90d2900ab0135bc24"
+default[:mongodb][:x86_64][:checksum] = "d764d869f2a3984251cfea5335cc6c53"
 
 ### GENERAL
 default[:mongodb][:dir]         = "/opt/mongodb-#{mongodb[:version]}" # For install from source

--- a/metadata.rb
+++ b/metadata.rb
@@ -247,8 +247,7 @@ attribute "mongodb/replica_set",
 attribute "mongodb/shard_server",
   :display_name => "MongoDB shard server",
   :description => "Specify that server should participate in sharding, by passing --shardsvr to mongod startup",
-  :recipes => ["mongodb::server"],
-  :default => false
+  :recipes => ["mongodb::server"]
 
 
 # Backups
@@ -338,7 +337,7 @@ attribute "mongodb/config_server/port",
   :display_name => "MongoDB config server port",
   :description => "Accept config server connections on the specified port",
   :recipes => ["mongodb::config_server"],
-  :default => 27019
+  :default => "27019"
 
 
 # mongos
@@ -369,5 +368,5 @@ attribute "mongodb/mongos/port",
   :display_name => "MongoDB sharding router port",
   :description => "Accept sharding router (mongos) connections on the specified port. Clients will normally connect to this just as they would a database server.",
   :recipes => ["mongodb::mongos"],
-  :default => 27017
+  :default => "27017"
 


### PR DESCRIPTION
Upgrades to 1.8, which is a pretty backwards compatible release. You should update your mongo client versions to match as well (there is a slight issue with the map reduce output option see MongoDB's release notes).

I also fixed some errors in the metadata.rb file which prevented the recipe from being uploaded.
