### PR TITLE
Here is what I needed to change when I installed MongoDB (apt)

### DIFF
--- a/attributes/mongodb.rb
+++ b/attributes/mongodb.rb
@@ -24,7 +24,7 @@ default[:mongodb][:server][:dir]                   = "/opt/mongodb-#{mongodb[:ve
 default[:mongodb][:server][:logpath]               = "/var/log/mongodb.log"
 default[:mongodb][:server][:pidfile]               = "/var/lib/mongodb/mongod.lock"
 default[:mongodb][:server][:port]                  = 27017
-default[:mongodb][:server][:system_init]           = "sysv"
+default[:mongodb][:server][:system_init]           = "upstart"
 
 ### EXTRA
 default[:mongodb][:server][:auth]                  = false
@@ -91,7 +91,7 @@ default[:mongodb][:config_server][:logpath] = "/var/log/mongodb-config.log"
 default[:mongodb][:config_server][:pidfile] = "/var/run/mongodb-config.pid"
 default[:mongodb][:config_server][:port]    = 27019
 default[:mongodb][:config_server][:verbose] = false
-
+default[:mongodb][:config_server][:system_init] = "upstart"
 
 
 ##########################################################################
@@ -102,3 +102,4 @@ default[:mongodb][:mongos][:logpath] = "/var/log/mongos.log"
 default[:mongodb][:mongos][:pidfile] = "/var/run/mongos.pid"
 default[:mongodb][:mongos][:port]    = 27017
 default[:mongodb][:mongos][:verbose] = false
+default[:mongodb][:mongos][:system_init] = "upstart"

--- a/libraries/mondogb_process.rb
+++ b/libraries/mondogb_process.rb
@@ -79,11 +79,9 @@ class Chef
 				subscribes :restart, resources(:template => "/etc/init/#{service_name}.conf") if node[:mongodb][:installed_from] == "apt"
 			end
 
-			logrotate "mongodb-#{service_name}" do
-				files config[:logpath]
-				frequency "daily"
-				rotate_count 7
-				compress true
+			logrotate_app "mongodb-#{service_name}" do
+				paths config[:logpath]
+				rotate 7
 				# http://www.mongodb.org/display/DOCS/Logging
 				restart_command "kill -SIGUSR1 `cat #{config[:pidfile]}`"
 			end

--- a/libraries/mondogb_process.rb
+++ b/libraries/mondogb_process.rb
@@ -40,7 +40,7 @@ class Chef
 			init_variables = variables[:init] || {}
 			init_variables[:server_type] = name.to_sym
 
-			case node[:mongodb][:system_init]
+			case config[:system_init]
       when "upstart"
 				template "/etc/init/#{service_name}.conf" do
 					source "mongodb.upstart.erb"

--- a/templates/default/logrotate.erb
+++ b/templates/default/logrotate.erb
@@ -1,0 +1,8 @@
+<%= @paths %> {
+        weekly
+        missingok
+        rotate <%= @rotate %>
+        compress
+        delaycompress
+        copytruncate
+}

--- a/templates/default/mongodb.conf.erb
+++ b/templates/default/mongodb.conf.erb
@@ -37,7 +37,7 @@
 		:replSet, # replica set name
 		:verbose, # Verbose logging output.
 	].each do |option|
-		if config[option] && !config[option].empty?
+		if config[option] && !config[option].to_s.empty?
 %>
 <%= option %> = <%= config[option] %>
 <%

--- a/templates/default/mongodb.upstart.erb
+++ b/templates/default/mongodb.upstart.erb
@@ -12,7 +12,7 @@ pre-start script
   mkdir -p <%= @config[:dbpath] %>
   chown -R mongodb:mongodb <%= @config[:dbpath] %>
   <% end %>
-  mkdir -p <%= File.dirname(@config[:logfile]) %>
+  mkdir -p <%= File.dirname(@config[:logpath]) %>
 end script
 
 start on runlevel [2345]

--- a/templates/default/mongodb.upstart.erb
+++ b/templates/default/mongodb.upstart.erb
@@ -37,7 +37,7 @@ script
   SHARDSVR=<%= node[:mongodb][:shard_server] %>
   <% end %>
 
-  <% unless server_type == 'mongos' %>
+  <% unless @server_type == 'mongos' %>
   REST=<%= node[:mongodb][:rest] %>
   SYNCDELAY="--syncdelay <%= node[:mongodb][:syncdelay] %>"
   <% end %>

--- a/templates/default/mongodb.upstart.erb
+++ b/templates/default/mongodb.upstart.erb
@@ -28,7 +28,7 @@ script
   CONF=<%= @config[:config] %>
   PIDFILE=<%= @config[:pidfile] %>
 
-  <% case server_type; when 'config_server' %>
+  <% case @server_type; when 'config_server' %>
   CONFIGSVR=--configsvr
   <% when 'mongos' %>
   CONFIGDB="--configdb <%= @configdb_server_list %>"


### PR DESCRIPTION
Hi,

First of all, thank you for a great cookbook! I needed to patch this cookbook to get it working.

Problem 1)

sysv is the default system_init. So, when we have:

```
  when "upstart"
            template "/etc/init/#{service_name}.conf" do
                source "mongodb.upstart.erb"
                owner "root"
                group "root"
                mode "0644"
                backup false
                variables init_variables
            end

    link "/etc/init.d/#{service_name}" do
      to "/lib/init/upstart-job"
    end
  when "sysv"
            template "/etc/init.d/#{service_name}" do
                source "mongodb.init.erb"
                mode "0755"
                backup false
                variables init_variables
            end
        end
```

When using sysv the template "/etc/init/#{service_name}.conf" isn't created. Then,

```
            subscribes :restart, resources(:template => "/etc/init.d/#{service_name}") if node[:mongodb][:installed_from] == "src"
            subscribes :restart, resources(:template => "/etc/init/#{service_name}.conf") if node[:mongodb][:installed_from] == "apt"
```

apt installation requires /etc/init/#{service_name}.conf that doesn't exist.

Problem 2)

http://community.opscode.com/cookbooks/logrotate doesn't include the required 'logrotate' definition. Instead it contains logrotate_app definition.

I don't know if my fixes are the correct ones but I am just letting you know what changes I made to my branch.
